### PR TITLE
Add Gnu source

### DIFF
--- a/Cask
+++ b/Cask
@@ -1,3 +1,4 @@
+(source gnu)
 (source melpa)
 
 (package "graphene" "@VERSION" "Friendly Emacs defaults")


### PR DESCRIPTION
Because flycheck depends on let-alist which is hosted on GNU ELPA.