### PR TITLE
Don't try to use non-existant smartparens variable

### DIFF
--- a/graphene-smartparens-config.el
+++ b/graphene-smartparens-config.el
@@ -55,7 +55,4 @@
                :unless '(sp-in-string-p)
                :actions '(insert wrap))
 
-(dolist (mode '(coffee-mode shell-mode))
-  (add-to-list 'sp-autoescape-string-quote-if-empty mode))
-
 (provide 'graphene-smartparens-config)


### PR DESCRIPTION
The smartparens variable `sp-autoescape-string-quote` no longer exists (removed in [this smartparens commit](https://github.com/Fuco1/smartparens/commit/2350913f1db3b3744d2ff23c9f0f1676c8c9289e) .  It's [been deprecated for a while](https://github.com/Fuco1/smartparens/commit/fa1428d4da6985ad3d950fb347284062367d6821) (see issue #33).

Similar functionality seems to have be driven by the newer customization variable: `sp-autoescape-string-quote`, which defaults to `true`.

If you accept this PR then graphene should probably depend on [smartparens v1.8.0](https://github.com/Fuco1/smartparens/releases/tag/v1.8.0), which is where the release containing this change.