### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Melpa Status](http://melpa.org/packages/graphene-badge.svg)](http://melpa.org/#/graphene)
 
 
-#Graphene
+# Graphene
 Graphene is a 'starter kit' for Emacs, in the vein of
 [Prelude](https://github.com/bbatsov/prelude) or
 [emacs-starter-kit](https://github.com/technomancy/emacs-starter-kit).
@@ -21,12 +21,12 @@ Textmate or Sublime Text find their feet quickly, it is not an attempt
 to turn Emacs into a sparkly GUI editor or IDE. It is minimal,
 lightweight, and respectful of the history and character of Emacs.
 
-#News
+# News
 Graphene 0.9 depends on [project-persist-drawer](https://github.com/rdallasgray/project-persist-drawer) and [ppd-sr-speedbar](https://github.com/rdallasgray/ppd-sr-speedbar) to hook a drawer into project activity.
 
 Custom variables are extended and refined -- see the relevant info documentation in the `graphene` group.
 
-##Sensible defaults
+## Sensible defaults
 Among many other things, Graphene turns off the Emacs startup screen,
 turns on
 [line wrapping](http://www.emacswiki.org/emacs/VisualLineMode), turns
@@ -35,7 +35,7 @@ moves automatic backups into the temp directory -- generally clears
 the way of small annoyances and makes things look and work the way
 you'd expect.
 
-##A clean look
+## A clean look
 Graphene includes its own 'meta-theme' which works hard to unify the
 look of the editor across a range of packages. This theme loads on top
 of any 'normal' theme you want to load, so you can still choose
@@ -45,7 +45,7 @@ It also sets more pleasant and modern default fonts appropriate to the
 host platform (which can be overridden), and maintains window size and
 position across sessions.
 
-##Discoverability
+## Discoverability
 At first Emacs can appear a little opaque; it is in fact a very
 discoverable environment, and Graphene tries to turn this up to
 maximum, by using
@@ -55,7 +55,7 @@ and [Company](http://company-mode.github.io) for in-editor
 completion. These allow gradual discovery of Emacs' functionality, and
 gradual building of speed and fluidity.
 
-##Essential packages
+## Essential packages
 The collection of packages Graphene includes prevents you having to
 research and discover on your own what the Emacs community has largely
 decided on as best-in-class packages.
@@ -78,7 +78,7 @@ decided on as best-in-class packages.
 - [Flycheck](https://github.com/flycheck/flycheck)
   For error checking
 
-##Installation
+## Installation
 Graphene is available on [Melpa](http://melpa.org).
 
 If you don't already have your Emacs set up to use the package
@@ -116,12 +116,12 @@ these. Once it's done, add this to your initialisation file:
 ```
 Restart Emacs, and away you go.
 
-##How do I ... ?
+## How do I ... ?
 All of the packages Graphene includes are well-documented, and I'll
 refer you to them rather than retread that documentation here. That
 said, there are some Graphene-specific things you need to know.
 
-###Keybindings
+### Keybindings
 Graphene creates some new keybindings, and alters some existing ones:
 
 - `C-x k` always kills the active buffer, rather than asking you which
@@ -141,7 +141,7 @@ Graphene creates some new keybindings, and alters some existing ones:
 Graphene used to bind the standard Mac keys for various purposes
 (Command-n for new buffer, for instance), but no longer does.
 
-###Projects
+### Projects
 [project-persist](https://github.com/rdallasgray/project-persist) uses
 the following keybindings:
 
@@ -150,12 +150,12 @@ the following keybindings:
 - `C-c P k` to close the current project
 - `C-c P d` to delete an existing project
 
-###Customising
+### Customising
 Try `M-x customize-group` and type 'graphene', for an idea of what can
 be customised; you may wish to set these programmatically in your init
 file, instead.
 
-##Contributions and feedback
+## Contributions and feedback
 Contributions to Graphene are very welcome, as are feedback and bug
 reports. The latter can be raised via the Issues section.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
